### PR TITLE
explicitly use gnu23

### DIFF
--- a/src/cli_arg_parsing.c
+++ b/src/cli_arg_parsing.c
@@ -2,8 +2,8 @@
 #include "cli_arg_parsing.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 void usage() {
 	printf ("-a\t\t\tshow all upcoming events (default is 5 events)\n");
@@ -13,7 +13,7 @@ void usage() {
 	exit(0);
 }
 
-void get_cli_args(int argc, char **argv, char **file_name, int *show_all_events) {
+void get_cli_args(int argc, char **argv, char **file_name, bool *show_all_events) {
 	int opt = 0;
 
 	const char *home = getenv("HOME");
@@ -34,7 +34,7 @@ void get_cli_args(int argc, char **argv, char **file_name, int *show_all_events)
 	while ((opt = getopt(argc, argv, "f:ahi")) != -1) {
 		switch(opt) {
 			case 'a':
-				*show_all_events = 1;
+				*show_all_events = true;
 				break;
 			case 'f':
 				*file_name = strcpy(*file_name, optarg);

--- a/src/cli_arg_parsing.h
+++ b/src/cli_arg_parsing.h
@@ -2,4 +2,4 @@
 
 void usage();
 
-void get_cli_args(int argc, char **argv, char **file_name, int *show_all_events);
+void get_cli_args(int argc, char **argv, char **file_name, bool *show_all_events);

--- a/src/date_time_handling.c
+++ b/src/date_time_handling.c
@@ -1,11 +1,11 @@
 #include "date_time_handling.h"
 #include "string_handling.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <assert.h>
 
 // buffer needs to contain a string with a strlen of 15 (format: "xxxxxxxxTxxxxxx")
 // or a strlen of 16 (format: "YYYYmmddTHHMMSSZ")

--- a/src/insert_event.c
+++ b/src/insert_event.c
@@ -10,7 +10,7 @@
 
 void insert_event(char *file_name) {
 	int myfd = open(file_name, O_RDWR);
-	int all_day_event = 0;
+	bool all_day_event = false;
 	char summary_buf[256] = "SUMMARY:";
 	char *input_buffer = &summary_buf[8];
 	uuid_t uuid;
@@ -106,7 +106,7 @@ void seek_cal_end(int fd) {
 	}
 }
 
-int binary_user_choice() {
+bool binary_user_choice() {
 	char input_buffer[64] = "";
 	if (fgets (input_buffer, sizeof(input_buffer), stdin) == NULL) {
 		printf ("an fgets error occured\n");
@@ -116,9 +116,9 @@ int binary_user_choice() {
 		exit(1);
 	}
 	if (input_buffer[0] == 'n' || input_buffer[0] == 'N') {
-		return 0;
+		return false;
 	} else if (input_buffer[0] == 'y' || input_buffer[0] == 'Y') {
-		return 1;
+		return true;
 	} else {
 		printf ("Please enter a N/n or Y/y character!\n");
 		exit(1);
@@ -126,7 +126,7 @@ int binary_user_choice() {
 }
 
 // char *start_or_end should contain "start" or "end"
-void get_dtstart_dtend(char input_buffer[], int all_day_event, char *start_or_end) {
+void get_dtstart_dtend(char input_buffer[], bool all_day_event, char *start_or_end) {
 	if (all_day_event) {
 		printf("Enter the %s date in YYYY-mm-dd format!\n", start_or_end);
 		if (fgets(input_buffer, 128, stdin) == NULL) {

--- a/src/insert_event.h
+++ b/src/insert_event.h
@@ -2,7 +2,7 @@
 
 void insert_event(char *file_name);
 void seek_cal_end(int fd);
-int binary_user_choice();
-void get_dtstart_dtend(char input_buffer[], int all_day_event, char *start_or_end);
+bool binary_user_choice();
+void get_dtstart_dtend(char input_buffer[], bool all_day_event, char *start_or_end);
 void form_dtstart_string(char dtstart_buffer[], char time_zone[]);
 void form_dtend_string(char dtend_buffer[], char time_zone[]);

--- a/src/list_handling.c
+++ b/src/list_handling.c
@@ -48,7 +48,7 @@ void free_list(struct event *head)
 
 // print_upcoming() also prints ongoing events
 // because you usually also want to see those
-void print_upcoming(struct event *head, char current_date[], int show_all_events) {
+void print_upcoming(struct event *head, char current_date[], bool show_all_events) {
 	int i = 0;
 	while (head != NULL) {
 		if (strcmp(head->end_date, current_date) >= 0) {

--- a/src/list_handling.h
+++ b/src/list_handling.h
@@ -10,4 +10,4 @@ struct event {
 void print_list(struct event *head);
 void sorted_insert(struct event **head, char start_date[], char end_date[], char summary[]);
 void free_list(struct event *head);
-void print_upcoming(struct event *head, char current_date[], int show_all_events);
+void print_upcoming(struct event *head, char current_date[], bool show_all_events);

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
 	char *ics_path = malloc(256);
 	ics_path = memset(ics_path, '\0', 256);
 
-	int show_all_events = 0;
+	bool show_all_events = false;
 
 	get_cli_args(argc, argv, &ics_path, &show_all_events);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,10 @@
 project(
   'ics_cli',
   'c',
-  default_options: 'warning_level=3',
+  default_options: [
+    'warning_level=3',
+    'c_std=gnu23',
+  ],
 )
 
 executable('icscli', 'main.c', 'cli_arg_parsing.c', 'date_time_handling.c', 'insert_event.c', \

--- a/src/string_handling.c
+++ b/src/string_handling.c
@@ -9,18 +9,18 @@ void cut_string(char my_string[], char delimiter, int side) {
 	char part1[256] = "";
 	char part2[256] = "";
 
-	int split = 0;
+	bool split = false;
 
 	int j = 0;
 	for (size_t i = 0; i < strlen(my_string); i++) {
 		if (my_string[i] == delimiter) {
-			if (split == 0) {
-				split = 1;
+			if (!split) {
+				split = true;
 				continue;
 			}
 		}
 
-		if (split == 0) {
+		if (!split) {
 			part1[i] = my_string[i];
 		} else {
 			part2[j] = my_string[i];

--- a/unit_tests/meson.build
+++ b/unit_tests/meson.build
@@ -1,7 +1,11 @@
 project(
   'ics_cli',
   'c',
-  default_options: 'warning_level=3')
+  default_options: [
+    'warning_level=3',
+    'c_std=gnu23',
+  ]
+)
 
 t1e = executable('test_print_upcoming', 'test_print_upcoming.c', '../src/parse_ics.c', '../src/string_handling.c', \
 '../src/list_handling.c', '../src/date_time_handling.c', '../src/file_handling.c')


### PR DESCRIPTION
Used `c_std=gnu23` in `meson.build`.\
Replaced ints used as booleans by real bools.