### PR TITLE
compile to llvm ir

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,6 +22,10 @@ generate-llvm: clean
 	clang -S -emit-llvm -std=gnu23 *.c
 	llvm-link -S -v *.ll -o icscli.ll
 
+[working-directory: 'src']
+llvm-to-binary: generate-llvm
+	clang icscli.ll -o icscli -luuid
+
 clean:
 	rm -rf src/builddir
 	rm -rf unit_tests/builddir

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ install: default
 
 [working-directory: 'src']
 generate-llvm: clean
-	clang -S -emit-llvm -std=gnu23 *.c
+	clang -g -Wall -S -emit-llvm -std=gnu23 *.c
 	llvm-link -S -v *.ll -o icscli.ll
 
 [working-directory: 'src']
@@ -30,3 +30,4 @@ clean:
 	rm -rf src/builddir
 	rm -rf unit_tests/builddir
 	rm -f src/*.ll
+	rm -f src/icscli

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ install: default
 	meson install -C src/builddir
 
 [working-directory: 'src']
-generate-llvm:
+generate-llvm: clean
 	clang -S -emit-llvm -std=gnu23 *.c
 	llvm-link -S -v *.ll -o icscli.ll
 

--- a/justfile
+++ b/justfile
@@ -17,6 +17,12 @@ test:
 install: default
 	meson install -C src/builddir
 
+[working-directory: 'src']
+generate-llvm:
+	clang -S -emit-llvm -std=gnu23 *.c
+	llvm-link -S -v *.ll -o icscli.ll
+
 clean:
 	rm -rf src/builddir
 	rm -rf unit_tests/builddir
+	rm -f src/*.ll

--- a/src/file_handling.c
+++ b/src/file_handling.c
@@ -36,7 +36,8 @@ void read_until_string(int fd, char buffer[], char search_string[]) {
 		i++;
 	}
 	size_t truncate_position = strlen(buffer) - strlen(search_string);
-	memset(&buffer[truncate_position], '\0', truncate_position);
+
+	memset(&buffer[truncate_position], '\0', strlen(buffer) - truncate_position);
 }
 
 // Seeks for a string in an open file.


### PR DESCRIPTION
- fixed memory bug that only occured when compiling with clang and using specific ics file
- recipe for creating a single llvm ir file
- recipe for compiling from that ll file to a working binary